### PR TITLE
Include methods to import full & individual bootstrap build in JS & CSS

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -114,7 +114,9 @@
     "at-rule-name-space-after": "always",
     "at-rule-semicolon-newline-after": "always",
     "at-rule-semicolon-space-before": "never",
-    "comment-empty-line-before": "always",
+    "comment-empty-line-before": ["always", {
+      ignore: "after-comment"
+    }],
     "indentation": 2,
     "max-empty-lines": 1,
     "no-eol-whitespace": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3965,6 +3965,12 @@
         }
       }
     },
+    "expose-loader": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-0.7.5.tgz",
+      "integrity": "sha512-iPowgKUZkTPX5PznYsmifVj9Bob0w2wTHVkt/eYNPSzyebkUgIedmskf/kcfEIWpiWjg3JRjnW+a17XypySMuw==",
+      "dev": true
+    },
     "express": {
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
@@ -6357,6 +6363,11 @@
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
       "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4="
     },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
     "js-base64": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
@@ -8086,6 +8097,11 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
+    },
+    "popper.js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
     },
     "portfinder": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   },
   "dependencies": {
     "bootstrap": "^4.1.1",
-    "js-image-generator": "^1.0.2"
+    "jquery": "^3.3.1",
+    "js-image-generator": "^1.0.2",
+    "popper.js": "^1.14.3"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",
@@ -49,6 +51,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
+    "expose-loader": "^0.7.5",
     "file-loader": "^1.1.11",
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.0",

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,5 +1,44 @@
-/* Dependency CSS */
+/* Boostrap 4 Full Bundle */
 @import "~bootstrap/scss/bootstrap";
+
+/* Bootstrap Individual CSS Files (Required) */
+/* @import "~bootstrap/scss/functions"; */
+/* @import "~bootstrap/scss/variables"; */
+/* @import "~bootstrap/scss/mixins"; */
+
+/* Bootstrap Individual CSS Files (Optional) */
+/* @import "~bootstrap/scss/root"; */
+/* @import "~bootstrap/scss/reboot"; */
+/* @import "~bootstrap/scss/type"; */
+/* @import "~bootstrap/scss/images"; */
+/* @import "~bootstrap/scss/code"; */
+/* @import "~bootstrap/scss/grid"; */
+/* @import "~bootstrap/scss/tables"; */
+/* @import "~bootstrap/scss/forms"; */
+/* @import "~bootstrap/scss/buttons"; */
+/* @import "~bootstrap/scss/transitions"; */
+/* @import "~bootstrap/scss/dropdown"; /* requiers popper.js */
+/* @import "~bootstrap/scss/button-group"; */
+/* @import "~bootstrap/scss/input-group"; */
+/* @import "~bootstrap/scss/custom-forms"; */
+/* @import "~bootstrap/scss/nav"; */
+/* @import "~bootstrap/scss/navbar"; */
+/* @import "~bootstrap/scss/card"; */
+/* @import "~bootstrap/scss/breadcrumb"; */
+/* @import "~bootstrap/scss/pagination"; */
+/* @import "~bootstrap/scss/badge"; */
+/* @import "~bootstrap/scss/jumbotron"; */
+/* @import "~bootstrap/scss/alert"; */
+/* @import "~bootstrap/scss/progress"; */
+/* @import "~bootstrap/scss/media"; */
+/* @import "~bootstrap/scss/list-group"; */
+/* @import "~bootstrap/scss/close"; */
+/* @import "~bootstrap/scss/modal"; */
+/* @import "~bootstrap/scss/tooltip"; /* requires popper.js */
+/* @import "~bootstrap/scss/popover"; */
+/* @import "~bootstrap/scss/carousel"; */
+/* @import "~bootstrap/scss/utilities"; */
+/* @import "~bootstrap/scss/print"; */
 
 /* App CSS */
 @import url("fonts.css");

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,25 @@
 import '../css/main.css';
 
+/* Boostrap 4 Full Bundles */
+import 'bootstrap/dist/js/bootstrap.bundle'; /* Includes popper.js */
+// import 'bootstrap'; /* Does not include popper. js */
+
+/* Bootstrap 4 Tooltip Dependency (Optional) */
+// import 'popper.js';
+
+/* Boostrap 4 Individual Components (Optional) */
+// import 'bootstrap/js/dist/alert';
+// import 'bootstrap/js/dist/button';
+// import 'bootstrap/js/dist/carousel';
+// import 'bootstrap/js/dist/collapse';
+// import 'bootstrap/js/dist/dropdown';
+// import 'bootstrap/js/dist/modal';
+// import 'bootstrap/js/dist/popover';
+// import 'bootstrap/js/dist/scrollspy';
+// import 'bootstrap/js/dist/tab';
+// import 'bootstrap/js/dist/tooltip'; /* requires popper.js */
+// import 'bootstrap/js/dist/util';
+
 if (process.env.NODE_ENV === 'development') {
   require('../index.html'); /* Require so webpack watches changes to html file */
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,13 @@ module.exports = (env, argv) => {
     module: {
       rules: [
         {
+          test: require.resolve('jquery'),
+          use: [
+            { loader: 'expose-loader', options: 'jQuery' },
+            { loader: 'expose-loader', options: '$' }
+          ]
+        },
+        {
           test: /\.(scss|css)$/,
           use: [{
             loader: MiniCssExtractPlugin.loader


### PR DESCRIPTION
## Description

Fixes #34

- Include in comments of index.js and main.css, all individual bootstrap 4 imports
- Include by default the full bootstrap 4 build
- Add popper.js and jQuery to npm package dependency
- Expose jQuery `$` & `jQuery` global objects via webpack config
- Change stylelintrc rule: comment-empty-line-before to allow multiple comment @import lines in main.css
