### PR TITLE
Fix example dist folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Bootstrap 4 is imported into main.css via `@import "~bootstrap/scss/bootstrap";`
 ``` 
 /* All files minified & gzipped */
 |-css/main.css
-|-favicon/
 |-fonts/
 |--OpenSans/
 |--[font_styles]


### PR DESCRIPTION
## Description: 
The README.md example of the dist folder structure incorrectly included the favicon folder.